### PR TITLE
Change datadir to /data/db for mongodb

### DIFF
--- a/unifi/docker-compose.yml
+++ b/unifi/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   mongo:
     image: mongo:3
     volumes:
-      - /volume1/docker/mongo:/data
+      - /volume1/docker/mongo:/data/db
 
   unifi-controller:
     image: dsully/unifi-controller:latest


### PR DESCRIPTION
The official docker mongodb documentation uses /data/db for the data directory.  Since it was /data before I had to change this path setting after creation and do some moving around while the container was running to get a smooth upgrade.